### PR TITLE
Run specs only in mock mode, not default or proxy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,8 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   tests:
-    name: ${{ matrix.gauge-env }} server
+    name: Mock server
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        gauge-env: [default, mock, validation-proxy]
     steps:
 
       - name: Checkout code
@@ -48,15 +45,10 @@ jobs:
         run: npm install -g @stoplight/prism-cli
 
       - name: Start Prism in mock mode
-        if: matrix.gauge-env == 'mock'
         run: prism mock openapi.yaml &
 
-      - name: Start Prism in validation proxy mode
-        if: matrix.gauge-env == 'validation-proxy'
-        run: prism proxy openapi.yaml https://petstore.swagger.io/v2 --errors &
-
-      - name: Run Gauge specs against ${{ matrix.gauge-env }} OpenAPI server
-        run: gauge run --env ${{ matrix.gauge-env }} specs
+      - name: Run Gauge specs against mock OpenAPI server
+        run: gauge run specs
 
       - name: Upload Gauge test report
         uses: actions/upload-artifact@v2

--- a/env/default/openapi.properties
+++ b/env/default/openapi.properties
@@ -1,1 +1,1 @@
-OPENAPI_HOST = https://petstore.swagger.io/v2
+OPENAPI_HOST = http://127.0.0.1:4010

--- a/env/mock/openapi.properties
+++ b/env/mock/openapi.properties
@@ -1,1 +1,0 @@
-OPENAPI_HOST = http://127.0.0.1:4010

--- a/env/validation-proxy/openapi.properties
+++ b/env/validation-proxy/openapi.properties
@@ -1,1 +1,0 @@
-OPENAPI_HOST = http://127.0.0.1:4010


### PR DESCRIPTION
We want the contract CI to just run in mock mode as this allows the
consumer to do trunk-based development i.e. to merge a new consumer-
driven change to the OpenAPI contract into trunk on both the contract
repo and their consumer repo, without needing to wait for the provider
to have actually implemented the new feature.

So we no longer run the contract Gauge specs against the real provider
or in [Prism's validation proxy mode][1], as our latest evolution of the
consumer-driven workflow pushes this responsibility to the provider's
CI, rather than the contract CI.

[1]: https://meta.stoplight.io/docs/prism/docs/guides/03-validation-proxy.md