### PR TITLE
Create permanent publicly available mock server

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -1,7 +1,7 @@
 ---
 name: Deploy mocks on Heroku
 on:  # yamllint disable-line rule:truthy
-  # Run the tests on every push to master branch
+  # Deploy the mocks on Heroku on every push to master branch
   push:
     branches:
       - master

--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -1,0 +1,67 @@
+---
+name: Deploy mocks on Heroku
+on:  # yamllint disable-line rule:truthy
+  # Run the tests on every push to master branch
+  push:
+    branches:
+      - master
+
+env:
+  HEROKU_APP_NAME: pets-consumer-contract-mock
+
+jobs:
+  tests:
+    name: Deploy mocks on Heroku
+    runs-on: ubuntu-20.04
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Gauge
+        uses: getgauge/setup-gauge@master
+        with:
+          gauge-plugins: python, html-report
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Create Heroku mock app
+        env:
+          # Needs `HEROKU_API_KEY` to have been set as a GitHub Actions secret:
+          # https://docs.github.com/en/actions/security-guides/encrypted-secrets
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          heroku create $HEROKU_APP_NAME \
+            --region eu \
+            --buildpack https://github.com/agilepathway/heroku-buildpack-prism.git \
+            || true
+          # Papertrail is a useful Heroku logging add-on: https://devcenter.heroku.com/articles/papertrail
+          heroku addons:create papertrail --app $HEROKU_APP_NAME || true
+
+      - name: Deploy Heroku mock
+        uses: tiagogouvea/github-dpl-action@master
+        with:
+          provider: heroku
+          app: ${{ env.HEROKU_APP_NAME }}
+          api-key: ${{ secrets.HEROKU_API_KEY }}
+
+      - name: Run Gauge specs against Heroku mock server
+        env:
+          # Python env var is temporary workaround for https://github.com/getgauge/gauge-python/issues/256
+          PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
+          OPENAPI_HOST: https://${{ env.HEROKU_APP_NAME }}.herokuapp.com
+        run: gauge run specs
+
+      - name: Upload Gauge test report
+        uses: actions/upload-artifact@v2
+        with:
+          name: gauge-html-report
+          path: reports/html-report/

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: prism mock openapi.yaml --errors -h 0.0.0.0 -p $PORT


### PR DESCRIPTION
Deploy the Prism mocks on a [Heroku][1] app, so that there is a
permanent publicly accessible mock server available.  The Heroku app is
automatically created on the fly if it doesn't already exist.

[1]: https://heroku.com